### PR TITLE
setDirty flag not set after recompute

### DIFF
--- a/src/main/java/com/coralblocks/coralme/PriceLevel.java
+++ b/src/main/java/com/coralblocks/coralme/PriceLevel.java
@@ -161,18 +161,30 @@ public class PriceLevel implements OrderListener {
     }
     
     public final long getSize() {
-        
+
         if (sizeDirty) {
-            
+
             size = 0;
-            
+
             for(Order o = head; o != null; o = o.next) {
-                
+
                 size += o.getOpenSize();
             }
+
+            sizeDirty = false;
         }
-        
+
         return size;
+    }
+
+    /**
+     * Check if the cached level size needs to be recalculated.
+     *
+     * @return {@code true} if {@link #getSize()} will recompute the level size
+     */
+    public final boolean isSizeDirty() {
+
+        return sizeDirty;
     }
 
     @Override

--- a/src/test/java/com/coralblocks/coralme/PriceLevelTest.java
+++ b/src/test/java/com/coralblocks/coralme/PriceLevelTest.java
@@ -19,6 +19,7 @@ public class PriceLevelTest {
 		order.init(new SystemTimestamper(), 1, "1", 1, "TEST", Side.BUY, 50, 100, Type.LIMIT, TimeInForce.DAY);
 
 		Assert.assertFalse(level.isSizeDirty());
+		Assert.assertFalse(level.isSizeDirty());
 		level.addOrder(order);
 		Assert.assertTrue(level.isSizeDirty());
 

--- a/src/test/java/com/coralblocks/coralme/PriceLevelTest.java
+++ b/src/test/java/com/coralblocks/coralme/PriceLevelTest.java
@@ -1,0 +1,27 @@
+package com.coralblocks.coralme;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.coralblocks.coralme.Order.Side;
+import com.coralblocks.coralme.Order.TimeInForce;
+import com.coralblocks.coralme.Order.Type;
+import com.coralblocks.coralme.util.SystemTimestamper;
+
+public class PriceLevelTest {
+
+	private final PriceLevel level = new PriceLevel("TEST", Side.BUY, 100);
+
+	@Test
+	public void testSizeDirtyReset() {
+
+		Order order = new Order();
+		order.init(new SystemTimestamper(), 1, "1", 1, "TEST", Side.BUY, 50, 100, Type.LIMIT, TimeInForce.DAY);
+
+		level.addOrder(order);
+		Assert.assertTrue(level.isSizeDirty());
+
+		Assert.assertEquals(50, level.getSize());
+		Assert.assertFalse(level.isSizeDirty());
+	}
+}

--- a/src/test/java/com/coralblocks/coralme/PriceLevelTest.java
+++ b/src/test/java/com/coralblocks/coralme/PriceLevelTest.java
@@ -19,7 +19,6 @@ public class PriceLevelTest {
 		order.init(new SystemTimestamper(), 1, "1", 1, "TEST", Side.BUY, 50, 100, Type.LIMIT, TimeInForce.DAY);
 
 		Assert.assertFalse(level.isSizeDirty());
-		Assert.assertFalse(level.isSizeDirty());
 		level.addOrder(order);
 		Assert.assertTrue(level.isSizeDirty());
 

--- a/src/test/java/com/coralblocks/coralme/PriceLevelTest.java
+++ b/src/test/java/com/coralblocks/coralme/PriceLevelTest.java
@@ -18,6 +18,7 @@ public class PriceLevelTest {
 		Order order = new Order();
 		order.init(new SystemTimestamper(), 1, "1", 1, "TEST", Side.BUY, 50, 100, Type.LIMIT, TimeInForce.DAY);
 
+		Assert.assertFalse(level.isSizeDirty());
 		level.addOrder(order);
 		Assert.assertTrue(level.isSizeDirty());
 


### PR DESCRIPTION
## Proposed Changes to CoralME
PriceLevel.getSize() recalculates the aggregate size when the sizeDirty flag is set. However, the flag was not cleared afterwards, causing every call to getSize() to traverse the order list.

Closes #9 

#### Before submitting please check the box below (put an 'x' inside of it)
- [ x] I have read and accepted the Contributor License Agreement (CLA) included in the repository
